### PR TITLE
Modified the insertion of the CRC into the buffer.

### DIFF
--- a/C/afproto.c
+++ b/C/afproto.c
@@ -99,9 +99,12 @@ int afproto_frame_data(const char *src,
     }
 
     // Set the CRC
-    // Dummy code
-    *((short*)dest) = crc;
-    dest += 2;
+
+    //Casting the CRC to lets the word be assigned to a non-word boundary in memory
+    *(dest) = (char)crc;
+    dest++;
+    *(dest) = (char)(crc >>8);
+    dest++;
 
     *(dest++) = AFPROTO_END_BYTE;
     *dest_len = dest - dest_start - 1;


### PR DESCRIPTION
Fixed a bug that was occurring on some microcontrollers where the CRC would be placed in the wrong place due to casting the buffer to a word from a char array.

Certain architectures were not allowing the word to be placed at a non-word memory boundary and the crc would over write the previous byte.